### PR TITLE
Style updates for TV

### DIFF
--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Platform} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 import {
   NavBarContainer,
@@ -21,7 +22,7 @@ const NavigationBar = ({currentRoute}: Props) => {
     navigation.navigate(stackName);
   };
 
-  if (!showNavBar) return null;
+  if (!showNavBar || Platform.isTV) return null;
 
   return (
     <NavBarContainer>

--- a/src/components/Settings/Setting/index.tsx
+++ b/src/components/Settings/Setting/index.tsx
@@ -58,9 +58,10 @@ const Setting = (props: Props) => {
         <Dropdown isOpen={open}>
           <DropdownComponent>
             {props.options?.map((option: string, index: number) => (
-              <DropdownItem onPress={() => handlePress(option)}>
+              <DropdownItem 
+                key={`option-${option}-${index}`} 
+                onPress={() => handlePress(option)}>
                 <DropdownItemTitle
-                  key={`option-${option}-${index}`}
                   isSelected={option === selectedOption}>
                   {option}
                 </DropdownItemTitle>

--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -15,7 +15,7 @@ import NotLoggedInComponent from './NotLoggedIn';
 import {useQuery} from '@tanstack/react-query';
 import {Anilist} from '@tdanks2000/anilist-wrapper';
 import {useAccessToken} from '../../contexts';
-import {Linking} from 'react-native';
+import {Linking, Platform} from 'react-native';
 import {storage} from '../../utils';
 import {ANILIST_ACCESS_TOKEN_STORAGE} from '../../utils/constants';
 import NotificationBell from './NotificationBell';
@@ -69,10 +69,25 @@ const TopBarComponent = ({hasJustLoggedIn}: Props) => {
         )}
 
         <IconContainer>
+          {Platform.isTV &&
+            <>
+              <IconItemContainer onPress={() => navigation.navigate('Search')}>
+                <IconItem name="search" />
+              </IconItemContainer>
+              <IconItemContainer onPress={() => navigation.navigate('Lists')}>
+                <IconItem name="list-ul" />
+              </IconItemContainer>
+            </>
+          }
           <IconItemContainer onPress={() => navigation.navigate('news', {})}>
             <IconItem name="newspaper" />
           </IconItemContainer>
           <NotificationBell />
+          {Platform.isTV &&
+            <IconItemContainer onPress={() => navigation.navigate('Settings')}>
+              <IconItem name="cog" />
+            </IconItemContainer>
+          }
         </IconContainer>
       </Container>
     </>

--- a/src/navigation/AppStack.tsx
+++ b/src/navigation/AppStack.tsx
@@ -23,7 +23,7 @@ import {NavigationBar} from '../components';
 import {RootStackParamList} from '../@types';
 import {utils} from '../utils';
 import {SyncingSettingScreen} from '../screens/SettingScreens';
-import Orientation from 'react-native-orientation-locker';
+import {OrientationLocker, LANDSCAPE, PORTRAIT} from 'react-native-orientation-locker';
 import {StatusBar, Platform} from 'react-native';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -46,18 +46,7 @@ const AppStack = () => {
   const [routeNameRef, setRouteNameRef] = useState<any>();
 
   React.useEffect(() => {
-    if (routeNameRef === 'VideoPlayer' || routeNameRef === 'ReaderScreen') {
-      if (routeNameRef === 'VideoPlayer') Orientation.lockToLandscape();
-      StatusBar.setHidden(true);
-      return utils.ToggleSystemNavigation(false);
-    }
-
-    if (!Platform.isTV) {
-      // lock to portrait
-      Orientation.lockToPortrait();
-    }
-    StatusBar.setHidden(false, 'slide');
-    utils.ToggleSystemNavigation(true);
+    utils.ToggleSystemNavigation(!(routeNameRef === 'VideoPlayer' || routeNameRef === 'ReaderScreen'));  
   }, [routeNameRef]);
 
   return (
@@ -76,6 +65,8 @@ const AppStack = () => {
           setRouteNameRef(currentRouteName);
         }
       }}>
+      <OrientationLocker orientation={Platform.isTV ? LANDSCAPE : PORTRAIT} />
+      <StatusBar hidden={false} showHideTransition={'slide'} />
       <Stack.Navigator
         initialRouteName="Home"
         screenOptions={{

--- a/src/screens/SettingsScreen/SettingsScreen.styles.ts
+++ b/src/screens/SettingsScreen/SettingsScreen.styles.ts
@@ -6,6 +6,7 @@ import Icon from 'react-native-vector-icons/FontAwesome6';
 
 export const BottomInfo = styled.View`
   margin-top: 25px;
+  margin-bottom: 25px;
 `;
 
 export const BottomImageContaoner = styled.View`

--- a/src/screens/VideoPlayerScreen/index.tsx
+++ b/src/screens/VideoPlayerScreen/index.tsx
@@ -11,7 +11,7 @@ import {View, Text, StatusBar, Platform} from 'react-native';
 import Video, {OnLoadData, OnProgressData} from 'react-native-video';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {useQuery} from '@tanstack/react-query';
-import Orientation from 'react-native-orientation-locker';
+import {OrientationLocker, LANDSCAPE} from 'react-native-orientation-locker';
 import {useFocusEffect, useNavigation} from '@react-navigation/native';
 import Toast from 'react-native-toast-message';
 
@@ -167,18 +167,6 @@ const VideoPlayerScreen: React.FC<Props> = ({route}): JSX.Element => {
       skipOutro();
     }
   }, [currentTime, duration]);
-
-  useEffect(() => {
-    Orientation.lockToLandscape();
-    StatusBar.setHidden(true);
-
-    return () => {
-      if (!Platform.isTV) {
-        Orientation.lockToPortrait();
-      }
-      StatusBar.setHidden(false, 'slide');
-    };
-  }, [episode_id]);
 
   const checkIfWatched = async () => {
     if (!duration) return;
@@ -340,6 +328,8 @@ const VideoPlayerScreen: React.FC<Props> = ({route}): JSX.Element => {
 
   return (
     <View>
+      <OrientationLocker orientation={LANDSCAPE} />
+      <StatusBar hidden={true} />
       <Player.PlayerControls
         paused={paused}
         setPaused={setPaused}

--- a/src/styles/sharedStyles.ts
+++ b/src/styles/sharedStyles.ts
@@ -1,10 +1,11 @@
 import {styled} from 'styled-components/native';
+import {Platform} from 'react-native';
 
 export const ScrollView = styled.ScrollView.attrs({
   showsHorizontalScrollIndicator: false,
   showsVerticalScrollIndicator: false,
   contentContainerStyle: {
-    paddingBottom: 300,
+    paddingBottom: Platform.isTV ? 25 : 100,
   },
 })``;
 


### PR DESCRIPTION
This PR includes some small adjustments to make the app a little more TV friendly. Also includes minor bugfixes
- Disable navbar entirely for TV. While the floating component still works on TVs, the overall feel of moving around with the remote feels awkward as-is. It sort-of "gets in the way" on all screens except the Home screen, and using the remote buttons to navigate to different screens is more convenient anyways.
- To make up for the above, I added navigation options at the top right (with news and notifications). This is inspired by the Kuro app which does something similar.
- Fixes a small styling 'issue' with the shared ScrollView. The amount of padding added was larger than necessary for the screens it is used on.
- Fixes an issue on the Setting component where the key for dropdown options was placed in child component rather than the root, causing console warnings about non unique key props.
- Changes the use of StatusBar and Orientation locking to use reactive components instead of wrapping them in useEffect. This is mostly for simplicity, but will also allow for easier customization if there ever needs to be events in the future for orientation changes

![Screenshot_1695775628](https://github.com/ApolloTv-team/ApolloTv/assets/19783312/77ed7622-0f77-435c-8815-48488cfb9329)
